### PR TITLE
Miscellaneous fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## 0.4.6 - 2025-12-16
+
+### Added
+
+- Complete registration page that users will be redirected to after self-registering via third party applications.
+- Add user registry id to audit log entries to aid debugging.
+
+### Changes
+
+- Default dataset visibility is now public.
+- Reword "Publisher Data Portal" to "Data Portal" and add some basic validation.
+- Hide user role dropdowns when users do not have permissions to change user roles.
+- Fix empty links to create reporting organisation page.
+- Fix "view datasets" button on reporting organisation page.
+
 ## 0.4.5 - 2025-12-15
 
 ### Added

--- a/iati_account_web/account/models.py
+++ b/iati_account_web/account/models.py
@@ -122,7 +122,10 @@ class IATIUser(AbstractUser):
     @property
     def log_label(self) -> str:
         """Short string to help identify users in audit logs"""
-        return f"{self.oidc_sub} ({self.unformatted_name})"
+        if self.registry_id:
+            return f"{self.oidc_sub} ({self.unformatted_name}) [crm id {self.registry_id}]"
+        else:
+            return f"{self.oidc_sub} ({self.unformatted_name})"
 
     def update_from_claims(self, claims: dict[str, str], include_sub: bool = False):
         """Update the user model fields from an OIDC claims dictionary

--- a/iati_account_web/data/forms.py
+++ b/iati_account_web/data/forms.py
@@ -10,7 +10,27 @@ from iati_account_web.settings import USER_ROLE_LOOKUP
 ALPHA_NUMERIC_HYPHEN_REGEX = re.compile(r"^[a-zA-Z0-9-_]+$")
 
 
-class OrganisationDetailsForm(forms.ModelForm):
+class OrganisationBaseForm(forms.ModelForm):
+    def clean_data_portal_url(self):
+        data_portal_url = self.cleaned_data["data_portal_url"]
+        if (
+            "d-portal.org" in data_portal_url
+            or "iatiregistry.org" in data_portal_url
+            or "aidstream.org" in data_portal_url
+        ):
+            raise ValidationError("Data portal should be the address of the reporting organisation's own data portal")
+
+        return data_portal_url
+
+    def clean_website(self):
+        website = self.cleaned_data["website"]
+        if "d-portal.org" in website or "iatiregistry.org" in website or "aidstream.org" in website:
+            raise ValidationError("Website should be the address of the reporting organisation's main website")
+
+        return website
+
+
+class OrganisationDetailsForm(OrganisationBaseForm):
     """Form for users to view/edit details of a reporting organisation"""
 
     class Meta:
@@ -28,7 +48,7 @@ class OrganisationDetailsForm(forms.ModelForm):
         labels = {
             "address": _("Postal address"),
             "contact_email": _("Contact email address"),
-            "data_portal_url": _("Publisher data portal"),
+            "data_portal_url": _("Data portal"),
             "default_licence_id": _("Default licence"),
             "description": _("Description"),
             "exclusions_policy_url": _("Exclusions policy website/document"),
@@ -92,7 +112,7 @@ class JoinOrganisationForm(forms.Form):
     )
 
 
-class CreateOrganisationForm(forms.ModelForm):
+class CreateOrganisationForm(OrganisationBaseForm):
     class Meta:
         model = ReportingOrganisation
         fields = "__all__"
@@ -106,7 +126,7 @@ class CreateOrganisationForm(forms.ModelForm):
         labels = {
             "address": _("Postal address"),
             "contact_email": _("Contact email address"),
-            "data_portal_url": _("Publisher data portal"),
+            "data_portal_url": _("Data portal"),
             "default_licence_id": _("Default licence"),
             "description": _("Description"),
             "exclusions_policy_url": _("Exclusions policy website/document"),

--- a/iati_account_web/data/forms.py
+++ b/iati_account_web/data/forms.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.forms import formset_factory
 from django.utils.translation import gettext_lazy as _
 from iati_account_web.data.models import Dataset, ReportingOrganisation, UserAndRole
+from iati_account_web.settings import USER_ROLE_LOOKUP
 
 ALPHA_NUMERIC_HYPHEN_REGEX = re.compile(r"^[a-zA-Z0-9-_]+$")
 
@@ -204,6 +205,10 @@ class OrgUserForm(forms.ModelForm):
         self.fields["role"].choices = [
             choice for choice in self.fields["role"].choices if choice[0] != "provider_admin"
         ]
+
+    @property
+    def get_role_display(self):
+        return USER_ROLE_LOOKUP[self["role"].value()]
 
 
 OrgUserFormSet = formset_factory(OrgUserForm, extra=0, can_delete=True)

--- a/iati_account_web/data/models.py
+++ b/iati_account_web/data/models.py
@@ -59,6 +59,10 @@ class UserAndRole(models.Model):
             return True
         return False
 
+    @property
+    def can_change_user_roles(self):
+        return self.role == "admin"
+
 
 class ReportingOrganisation(models.Model):
     class Meta:

--- a/iati_account_web/data/templates/data/multiple_org_list.html
+++ b/iati_account_web/data/templates/data/multiple_org_list.html
@@ -35,12 +35,12 @@ IATI Account: My Data
 {% if not orgs %}
 <div class="iati-callout">
     <p>It looks like you're not associated with any organisations.  To start, you can 
-        <a href="{% url 'data:join-reporting-org' %}">search for your organisation</a>, or you can <a href="#">create an new reporting organisation</a> if your organisation is starting it's publishing journey with IATI.
+        <a href="{% url 'data:join-reporting-org' %}">search for your organisation</a>, or you can <a href="{% url 'data:create-reporting-org' %}">create a new reporting organisation</a> if your organisation is starting it's publishing journey with IATI.
     </p>
 </div><br/>
 {% else %}
 <p class="iati-message">
-    If you need to join another organisation you can <a href="{% url 'data:join-reporting-org' %}">search by clicking here</a>, or if you can <a href="{% url 'data:create-reporting-org' %}">create an new reporting organisation</a> if you are involved in starting another organisation's publishing journey with IATI.
+    If you need to join another organisation you can <a href="{% url 'data:join-reporting-org' %}">search by clicking here</a>, or if you can <a href="{% url 'data:create-reporting-org' %}">create a new reporting organisation</a> if you are involved in starting another organisation's publishing journey with IATI.
 </p><br/>
 {% endif %}
 

--- a/iati_account_web/data/templates/data/org_detail.html
+++ b/iati_account_web/data/templates/data/org_detail.html
@@ -161,7 +161,7 @@ IATI Account: My Data
                 <strong>Organisation short name:</strong> <code>{{ org.short_name }}</code><br/>
                 <strong>Organisation identifier:</strong> <code>{{ org.organisation_identifier }}</code>
             </p>
-            <button class="iati-button" onclick="openDatasetPage(this)" data-href="{% url 'data:dataset-list' oid=org.oid %}">View Datasets</button>
+            <button class="iati-button" onclick="openDatasetPage(this)" data-href="{% url 'data:dataset-list' oid=org.oid %}" type="button">View Datasets</button>
         </div>
     </div><br/>
 

--- a/iati_account_web/data/templates/data/org_detail.html
+++ b/iati_account_web/data/templates/data/org_detail.html
@@ -407,8 +407,8 @@ IATI Account: My Data
                             <td style="display:none;">{{ user_form.oid }}</td>
                             <td>{{ user_form.name }} {{ user_form.name.value }}</td>
                             <td>{{ user_form.email }} {{ user_form.email.value }}</td>
-                            <td>{{ user_form.role }}</td>
-                            <td>{{ user_form.DELETE }}</td>
+                            <td>{% if  this_user.can_change_user_roles %} {{ user_form.role }} {% else %} {{ user_form.get_role_display }} {% endif %}</td>
+                            <td>{% if  this_user.can_change_user_roles %} {{ user_form.DELETE }} {% endif %}</td>
                         </tr>
                         {% endif %}
                         {% endfor %}

--- a/iati_account_web/data/views.py
+++ b/iati_account_web/data/views.py
@@ -696,7 +696,7 @@ def create_dataset(request: HttpRequest, oid: str) -> HttpResponse:  # noqa: C90
                 initial={
                     "licence_id": reporting_org.default_licence_id,
                     "source_type": reporting_org.reporting_source_type,
-                    "visibility": "private",
+                    "visibility": "public",
                 }
             )
         ),

--- a/iati_account_web/welcome/templates/welcome/complete_registration.html
+++ b/iati_account_web/welcome/templates/welcome/complete_registration.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}
+IATI Account: Complete Registration
+{% endblock %}
+
+{% block body %}
+
+<h1>Please complete the setup of your IATI Account</h1>
+<p>Before you can use any other publishing tools we need to complete the sign up process in <a href="{% url 'welcome:home' %}">IATI Account</a>.  Please sign into your account to complete the process and then you can return to the tool you were using.</p>
+
+<form style="display:flex;flex-direction: column; align-items: center;">
+  <button class="iati-button iati-button--submit" type="submit"
+    formaction="{% url 'oidc_authentication_init' %}">Sign in with
+    IATI</button>
+</form>
+
+{% endblock %}

--- a/iati_account_web/welcome/templates/welcome/home.html
+++ b/iati_account_web/welcome/templates/welcome/home.html
@@ -53,7 +53,7 @@ IATI Account: Home
 <h3>Your organisations</h3>
 {% if not orgs %}
   <p>It looks like you're not associated with any organisations.  To start, you can 
-      <a href="{% url 'data:join-reporting-org' %}">search for your organisation</a>, or you can <a href="#">create an new reporting organisation</a> if your organisation is starting it's publishing journey with IATI.
+      <a href="{% url 'data:join-reporting-org' %}">search for your organisation</a>, or you can <a href="{% url 'data:create-reporting-org' %}">create a new reporting organisation</a> if your organisation is starting its publishing journey with IATI.
   </p>
 {% else %}
   <div class="iati-table" style="width:100%;">

--- a/iati_account_web/welcome/templates/welcome/index.html
+++ b/iati_account_web/welcome/templates/welcome/index.html
@@ -13,7 +13,7 @@ IATI Account
   <p>{% blocktranslate %}You should have received an email with instructions on how to do this. If not, please <a href="https://iatistandard.org/en/guidance/get-support/">contact us</a>.{% endblocktranslate %}</p>
 </div>
 
-<div style="display:flex;flex-direction: row; align-items: center;">
+<div style="display:flex;flex-direction: row; align-items: center; flex-wrap: wrap;">
   <div style="flex: 1;">
 {% comment %}Translators: Welcome text to the tool {% endcomment %}
     <h1>{% blocktranslate %}Welcome to your IATI Account{% endblocktranslate %}</h1>

--- a/iati_account_web/welcome/urls.py
+++ b/iati_account_web/welcome/urls.py
@@ -6,4 +6,5 @@ app_name = "welcome"
 
 urlpatterns = [
     path("", views.index, name="home"),
+    path("complete-registration", views.complete_registration, name="complete-registration"),
 ]

--- a/iati_account_web/welcome/views.py
+++ b/iati_account_web/welcome/views.py
@@ -31,3 +31,21 @@ def index(request: HttpRequest) -> HttpResponse:
         template = loader.get_template("welcome/index.html")
 
     return HttpResponse(template.render(context, request))
+
+
+def complete_registration(request: HttpRequest) -> HttpResponse:
+    """Simple page to inform a user that they need to complete registration in IATI Account
+
+    This is called when a user tries to log into a third party application (e.g., IATI Publisher)
+    with an unprovisioned account.
+
+    Parameters
+    ----------
+    request : HttpRequest
+
+    Returns
+    -------
+    HttpResponseRedirect
+    """
+    template = loader.get_template("welcome/complete_registration.html")
+    return HttpResponse(template.render({}, request))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iati-account-web"
-version = "0.4.5"
+version = "0.4.6"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]


### PR DESCRIPTION
This PR closes a number of issues in advance of launch.

Additions:

- Complete registration page that users will be redirected to after self-registering via third party applications #53 .
- Add user registry id to audit log entries to aid debugging.

Changes:

- Default dataset visibility is now public #50 .
- Reword "Publisher Data Portal" to "Data Portal" and add some basic validation #28.
- Hide user role dropdowns when users do not have permissions to change user roles #47.
- Fix empty links to create reporting organisation page #45.
- Fix "view datasets" button on reporting organisation page.
