### PR TITLE
Immediate post launch fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.8 - 2025-12-19
+
+### Added
+
+- Link to help site.
+- Basic CLI audit log viewer to support debugging.
+
+### Changes
+
+- Remove Django admin pages.
+- Fixed error where users could not select the dataset page size.
+- Removed mailing list subscriptions from account completion.
+- Fixed bug where join organisation page could cause a crash from an empty form submission.
+
 ## 0.4.7 - 2025-12-16
 
 ### Added

--- a/audit_log_viewer.py
+++ b/audit_log_viewer.py
@@ -1,0 +1,39 @@
+import argparse
+import sys
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from iati_account_web.audit_log_formatter import decode_and_decrypt_log_entry
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="IATI Account Audit Log Viewer",
+        description="Decrypts IATI Account audit log entries",
+    )
+    parser.add_argument("private_key", action="store", help="Private key for decryption")
+    parser.add_argument(
+        "-f", "--file", action="store", help="Log file to parse, otherwise parses from stdin", default=""
+    )
+    args = parser.parse_args()
+
+    private_key_bytes = None
+
+    with open(args.private_key, "rb") as private_key_fh:
+        private_key_bytes = private_key_fh.read()
+
+    private_key = serialization.load_pem_private_key(private_key_bytes, None)
+    if not isinstance(private_key, rsa.RSAPrivateKey):
+        raise AssertionError("private_key not of expected type rsa.RSAPrivateKey")
+
+    if args.file:
+        fh = open(args.file, "r")
+    else:
+        fh = sys.stdin
+
+    for line in fh:
+        print(decode_and_decrypt_log_entry(line, private_key))
+
+
+if __name__ == "__main__":
+    main()

--- a/iati_account_web/account/models.py
+++ b/iati_account_web/account/models.py
@@ -45,7 +45,7 @@ class IATIUser(AbstractUser):
 
     @property
     def has_complete_profile(self) -> bool:
-        return self.has_complete_geolocation and self.has_complete_names and self.has_subscribed_to_mailing_lists
+        return self.has_complete_geolocation and self.has_complete_names
 
     @property
     def first_registration_use_cases(self) -> str:

--- a/iati_account_web/data/templates/data/join_reporting_org.html
+++ b/iati_account_web/data/templates/data/join_reporting_org.html
@@ -64,6 +64,7 @@ function selectOrg(orgRow) {
     document.getElementById("foundOrgBox").style.display = "block";
     document.getElementById("id_human_readable_name").value = selectedOrgRow.children[0].innerHTML;
     document.getElementById("id_org_id").value = selectedOrgRow.dataset.orgId;
+    document.getElementById("joinOrgButton").disabled = false;
 }
 </script>
 
@@ -125,7 +126,7 @@ IATI Account: Find your organisation
             {{ form.human_readable_name }}
             {{ form.org_id }}
         </div><br/>
-        <button class="iati-form__submit iati-button iati-button--submit" type="submit">Join Organisation</button>
+        <button id="joinOrgButton" class="iati-form__submit iati-button iati-button--submit" type="submit" disabled>Join Organisation</button>
     </div><br/>
 
     <div class="iati-table">

--- a/iati_account_web/data/views.py
+++ b/iati_account_web/data/views.py
@@ -548,8 +548,7 @@ def dataset_list(request: HttpRequest, oid: str) -> HttpResponse:
         return preflight.redirect
 
     page = request.GET.get("page", 1)
-    page_size = 2
-    # page_size = request.GET.get("page_size", 100)
+    page_size = request.GET.get("page_size", 24)
 
     session = RegisterYourDataSession(request.session["oidc_access_token"], allow_redirects=True)
 

--- a/iati_account_web/settings.py
+++ b/iati_account_web/settings.py
@@ -160,7 +160,6 @@ INSTALLED_APPS = [
     "iati_account_web.account.apps.AccountConfig",
     "iati_account_web.data.apps.DataConfig",
     "django.contrib.auth",
-    "django.contrib.admin",
     "mozilla_django_oidc",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/iati_account_web/templates/base.html
+++ b/iati_account_web/templates/base.html
@@ -69,7 +69,7 @@
             {% endif %}
           </li>
           <li class="iati-mobile-nav__item">
-            <a href="#" class="iati-mobile-nav__link">Help Docs</a>
+            <a href="https://docs.account.iatistandard.org/en/latest/" class="iati-mobile-nav__link">Help Docs</a>
           </li>
         </ul>
       </nav>
@@ -115,7 +115,7 @@
         <div class="iati-header__container iati-brand-background__content">
           <div class="iati-header__actions">
             {% include 'components/language_switcher.html' %}
-            <button class="iati-button iati-button--light hide--mobile-nav">
+            <button class="iati-button iati-button--light hide--mobile-nav" onclick="window.location.assign('https://docs.account.iatistandard.org/en/latest/')">
               <span>Help Docs</span>
               <i class="iati-icon iati-icon--info"></i>
             </button>
@@ -175,9 +175,6 @@
               <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">GNU AGPL</a>.
             </p>
             <p>Please report bugs and request features using <a href="https://github.com/IATI/iati-account-web/issues">GitHub issues</a> or via <a href="https://iatistandard.org/en/guidance/get-support/">IATI Support</a>.
-            </p>
-            <p>
-              .
             </p>
           </div>
         </div>

--- a/iati_account_web/urls.py
+++ b/iati_account_web/urls.py
@@ -16,14 +16,12 @@ Including another URLconf
 """
 
 from django.conf.urls.i18n import i18n_patterns
-from django.contrib import admin
 from django.urls import include, path
 from iati_account_web.settings import env
 
 from .views import logout, post_login, provision_account
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
     path("identity/oidc/", include("mozilla_django_oidc.urls")),
     path("identity/post-login", post_login, name="post-login"),
     path("identity/logout", logout, name="logout"),

--- a/iati_account_web/welcome/templates/welcome/home.html
+++ b/iati_account_web/welcome/templates/welcome/home.html
@@ -42,9 +42,6 @@ IATI Account: Home
     {% if not user.has_complete_geolocation %}
       <li>Could you tell us <a href="{% url 'account:home' %}#geolocation">where you are in the world?</a>. This helps us understand the geographical reach of IATI and where you're based</li>
     {% endif %}
-    {% if not user.has_subscribed_to_mailing_lists %}
-      <li>Why not <a href="{% url 'account:home' %}#mailing-lists">subscribe to our mailing lists</a> to help you stay up-to-date with IATI.</li>
-    {% endif %}
   </ul>
 {% else %}
   <p>Your profile is complete</p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iati-account-web"
-version = "0.4.7"
+version = "0.4.8"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]


### PR DESCRIPTION
This PR applies some immediate post-launch fixes.  Specifically it:

Adds:

- Link to help site #62 .
- Basic CLI audit log viewer to support debugging.

Changes/fixes:

- Remove Django admin pages.
- Fixed error where users could not select the dataset page size.
- Removed mailing list subscriptions from account completion #61 .
- Fixed bug where join organisation page could cause a crash from an empty form submission #63 .
