### PR TITLE
Enable editors to edit dataset visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.13 - 2026-04-15
+
+### Fixed
+
+- Fixed editor permissions to allow updating dataset visibility.
+
 ## 0.4.12 - 2026-03-16
 
 ### Fixed

--- a/iati_account_web/data/views.py
+++ b/iati_account_web/data/views.py
@@ -763,10 +763,7 @@ def dataset_detail(request: HttpRequest, oid: str, dataset_id: str) -> HttpRespo
         )
         raise exc
 
-    fields_editable_status: dict[str, bool] = {
-        f: this_user.can_edit_dataset for f in updateable_fields if f != "visibility"
-    }
-    fields_editable_status["visibility"] = this_user.can_change_dataset_visibility
+    fields_editable_status: dict[str, bool] = {f: this_user.can_edit_dataset for f in updateable_fields}
 
     form = DatasetDetailsForm(instance=dataset)
     if request.POST:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iati-account-web"
-version = "0.4.12"
+version = "0.4.13"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]


### PR DESCRIPTION
This PR alters the dataset detail form to allow EDITORs to update dataset visibility. It should only be merged once the permission handling on RYD has been updated to allow this, as per https://github.com/IATI/register-your-data-api/issues/76