### PR TITLE
Small tweaks to work with provider admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.13 - 2026-04-20
+
+### Added
+
+- Permissions for provider admin users.
+- User role lozenges for provider admin.
+
 ## 0.4.12 - 2026-03-16
 
 ### Fixed

--- a/iati_account_web/data/models.py
+++ b/iati_account_web/data/models.py
@@ -46,19 +46,19 @@ class UserAndRole(models.Model):
 
     @property
     def can_edit_dataset(self):
-        if self.role in ("admin", "editor", "super_admin"):
+        if self.role in ("admin", "editor", "super_admin", "provider_admin"):
             return True
         return False
 
     @property
     def can_change_dataset_visibility(self):
-        if self.role in ("admin", "super_admin"):
+        if self.role in ("admin", "super_admin", "provider_admin"):
             return True
         return False
 
     @property
     def can_delete_dataset(self):
-        if self.role in ("admin", "editor", "super_admin"):
+        if self.role in ("admin", "editor", "super_admin", "provider_admin"):
             return True
         return False
 

--- a/iati_account_web/data/templates/data/components/user_role_lozenge.html
+++ b/iati_account_web/data/templates/data/components/user_role_lozenge.html
@@ -1,0 +1,11 @@
+{% if this_user.role == "admin" %}
+    an <span class="iati-account-lozenge iati-account-lozenge-teal-90">ADMIN</span>.
+{% elif this_user.role == "editor" %}
+    an <span class="iati-account-lozenge iati-account-lozenge-purple-90">EDITOR</span>.
+{% elif this_user.role == "contributor" %}
+    a <span class="iati-account-lozenge iati-account-lozenge-grey-90">CONTRIBUTOR</span>.
+{% elif this_user.role == "super_admin" %}
+    a <span class="iati-account-lozenge iati-account-lozenge-red-90">SUPERADMIN</span>.
+{% elif this_user.role == "provider_admin" %}
+    a <span class="iati-account-lozenge iati-account-lozenge-red-90">PROVIDER ADMIN</span>.
+{% endif %}

--- a/iati_account_web/data/templates/data/create_dataset.html
+++ b/iati_account_web/data/templates/data/create_dataset.html
@@ -50,15 +50,7 @@ IATI Account: My Data
     {% endif %}
 </h2>
 <p>You are creating a dataset for this organisation as 
-    {% if this_user.role == "admin" %}
-        an <span class="iati-account-lozenge iati-account-lozenge-teal-90">ADMIN</span>.
-    {% elif this_user.role == "editor" %}
-        an <span class="iati-account-lozenge iati-account-lozenge-purple-90">EDITOR</span>.
-    {% elif this_user.role == "contributor" %}
-        a <span class="iati-account-lozenge iati-account-lozenge-grey-90">CONTRIBUTOR</span>.
-    {% elif this_user.role == "super_admin" %}
-        a <span class="iati-account-lozenge iati-account-lozenge-red-90">SUPERADMIN</span>.
-    {% endif %}
+    {% include 'data/components/user_role_lozenge.html' %}
 </p>
 
 <div>

--- a/iati_account_web/data/templates/data/dataset_detail.html
+++ b/iati_account_web/data/templates/data/dataset_detail.html
@@ -91,15 +91,7 @@ IATI Account: My Data
     {% endif %}
 </h2>
 <p>You are viewing/editing this dataset for this organisation as 
-    {% if this_user.role == "admin" %}
-        an <span class="iati-account-lozenge iati-account-lozenge-teal-90">ADMIN</span>.
-    {% elif this_user.role == "editor" %}
-        an <span class="iati-account-lozenge iati-account-lozenge-purple-90">EDITOR</span>.
-    {% elif this_user.role == "contributor" %}
-        a <span class="iati-account-lozenge iati-account-lozenge-grey-90">CONTRIBUTOR</span>.
-    {% elif this_user.role == "super_admin" %}
-        a <span class="iati-account-lozenge iati-account-lozenge-red-90">SUPERADMIN</span>.
-    {% endif %}
+    {% include 'data/components/user_role_lozenge.html' %}
 </p>
 
 <div>

--- a/iati_account_web/data/templates/data/dataset_list.html
+++ b/iati_account_web/data/templates/data/dataset_list.html
@@ -59,15 +59,7 @@ IATI Account: My Data
         {% endif %}
     </h2>
     <p>You are viewing the dataset list for this organisation as 
-        {% if this_user.role == "admin" %}
-            an <span class="iati-account-lozenge iati-account-lozenge-teal-90">ADMIN</span>.
-        {% elif this_user.role == "editor" %}
-            an <span class="iati-account-lozenge iati-account-lozenge-purple-90">EDITOR</span>.
-        {% elif this_user.role == "contributor" %}
-            a <span class="iati-account-lozenge iati-account-lozenge-grey-90">CONTRIBUTOR</span>.
-        {% elif this_user.role == "super_admin" %}
-            a <span class="iati-account-lozenge iati-account-lozenge-red-90">SUPERADMIN</span>.
-        {% endif %}
+        {% include 'data/components/user_role_lozenge.html' %}
     </p>
 
     <div>

--- a/iati_account_web/data/templates/data/org_detail.html
+++ b/iati_account_web/data/templates/data/org_detail.html
@@ -131,15 +131,7 @@ IATI Account: My Data
         {% endif %}
     </h2>
     <p>You are viewing/editing this organisation as 
-        {% if this_user.role == "admin" %}
-            an <span class="iati-account-lozenge iati-account-lozenge-teal-90">ADMIN</span>.
-        {% elif this_user.role == "editor" %}
-            an <span class="iati-account-lozenge iati-account-lozenge-purple-90">EDITOR</span>.
-        {% elif this_user.role == "contributor" %}
-            a <span class="iati-account-lozenge iati-account-lozenge-grey-90">CONTRIBUTOR</span>.
-        {% elif this_user.role == "super_admin" %}
-            a <span class="iati-account-lozenge iati-account-lozenge-red-90">SUPERADMIN</span>.
-        {% endif %}
+        {% include 'data/components/user_role_lozenge.html' %}
     </p>
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iati-account-web"
-version = "0.4.12"
+version = "0.4.13"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]


### PR DESCRIPTION
This PR adds two small tweaks to enable it to work with provider admin:

- Determines provider admin permissions so that the interface can respond to the logged-in user's permissions,
- User roles (in the lozenge at the top of an organisation or dataset page) now include provider admin.