### PR TITLE
Fix permissions, design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.15 - 2026-05-06
+
+### Fixed
+
+- Updated editor permissions to allow changing dataset visibility.
+- Updated contributor permissions to allow editing dataset fields (except visibility).
+
 ## 0.4.14 - 2026-05-05
 
 ### Added

--- a/iati_account_web/data/models.py
+++ b/iati_account_web/data/models.py
@@ -46,7 +46,7 @@ class UserAndRole(models.Model):
 
     @property
     def can_edit_dataset(self):
-        if self.role in ("admin", "editor", "super_admin", "provider_admin"):
+        if self.role in ("admin", "editor", "contributor", "super_admin", "provider_admin"):
             return True
         return False
 

--- a/iati_account_web/data/models.py
+++ b/iati_account_web/data/models.py
@@ -52,7 +52,7 @@ class UserAndRole(models.Model):
 
     @property
     def can_change_dataset_visibility(self):
-        if self.role in ("admin", "super_admin", "provider_admin"):
+        if self.role in ("admin", "editor", "super_admin", "provider_admin"):
             return True
         return False
 

--- a/iati_account_web/data/templates/data/dataset_detail.html
+++ b/iati_account_web/data/templates/data/dataset_detail.html
@@ -169,7 +169,9 @@ IATI Account: My Data
                 <div>
                     <button id="saveChangesButton" class="iati-form__submit iati-button iati-button--submit" type="button" style="display: none;" onclick="saveChangesAction()">Save</button>
                     <button id="discardChangesButton" class="iati-form__submit iati-button" type="button" style="display: none;" onclick="discardChangesAction()">Discard Changes</button>
-                    <button id="deleteButton" class="iati-form__submit iati-button" type="button" onclick="deleteAction()">Delete</button>
+                    {% if this_user.can_delete_dataset %}
+                        <button id="deleteButton" class="iati-form__submit iati-button" type="button" onclick="deleteAction()">Delete</button>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>

--- a/iati_account_web/data/views.py
+++ b/iati_account_web/data/views.py
@@ -770,7 +770,16 @@ def dataset_detail(request: HttpRequest, oid: str, dataset_id: str) -> HttpRespo
 
     form = DatasetDetailsForm(instance=dataset)
     if request.POST:
-        form = form = DatasetDetailsForm(request.POST, instance=dataset)
+        form = DatasetDetailsForm(request.POST, instance=dataset)
+
+    # Set field editability based on user role. This must happen before
+    # is_valid() so disabled fields fall back to the instance value rather
+    # than failing required-field validation when the disabled HTML control
+    # was not submitted.
+    for field_name, editable in fields_editable_status.items():
+        form.fields[field_name].disabled = not editable
+
+    if request.POST:
         app_logger.debug(f"Updating a dataset - form validation state: {form.is_valid()}")
         if form.is_valid():
             try:
@@ -836,11 +845,6 @@ def dataset_detail(request: HttpRequest, oid: str, dataset_id: str) -> HttpRespo
                 messages.WARNING,
                 "There was a problem in updating the new dataset.  Please correct the " "errors below and try again.",
             )
-
-    # Here we have an organisation change form and we need to set the editability
-    # of certain fields depending on the user role.
-    for field_name, editable in fields_editable_status.items():
-        form.fields[field_name].disabled = not editable
 
     # Build the context and then render the page.
     context = {

--- a/iati_account_web/templates/base.html
+++ b/iati_account_web/templates/base.html
@@ -17,7 +17,7 @@
       }
     </style>
 
-    <script src="https://cdn.jsdelivr.net/npm/iati-design-system@4.5.1/dist/js/iati.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/iati-design-system@4.9.0/dist/js/iati.js"></script>
 
     <!-- Privacy-friendly analytics by Plausible -->
     <script async src="https://plausible.io/js/pa-DMCWMNhG5ofGba9NFvGGJ.js"></script>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iati-account-web"
-version = "0.4.14"
+version = "0.4.15"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]


### PR DESCRIPTION
This PR:
* Updates the editor permissions to allow changing dataset visibility as per new requirements.
* Updates the contributor permissions to match RYD and old documentation (contributors can create and edit datasets, except they can't change the visibility field)
* Updates design system JS file to match CSS 