### PR TITLE
Change forum URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.16 - 2026-05-12
+
+### Changes
+
+- Changed external forum URL.
+
 ## 0.4.15 - 2026-05-06
 
 ### Fixed

--- a/iati_account_web/welcome/templates/welcome/home.html
+++ b/iati_account_web/welcome/templates/welcome/home.html
@@ -74,7 +74,7 @@ IATI Account: Home
 
 <h3>IATI Tools</h3>
 <ul>
-  <li><a href="https://iati.discussion.community/">IATI Connect</a>: An online platform where members of the IATI community can discuss topics related to aid transparency and share insights.</li>
+  <li><a href="https://new.iatistandard.org/pages/forum">IATI Connect</a>: An online platform where members of the IATI community can discuss topics related to aid transparency and share insights.</li>
   <li><a href="https://publisher.iatistandard.org">IATI Publisher</a>: You can use this to prepare and publish your IATI data if you have less than 100 activities. <a href="https://docs.publisher.iatistandard.org/en/latest/">Read more about IATI Publisher</a>.</li>
 </ul>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iati-account-web"
-version = "0.4.15"
+version = "0.4.16"
 requires-python = ">= 3.12.11"
 readme = "README.md"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]


### PR DESCRIPTION
This PR makes a very small change to the URL for the IATI Connect forum.

Note: it is developed against `sk-fix-permissions--design-system` and PR #111 should be merged before this one.  The base will need changing before a merge.