### PR TITLE
Handle errors in audit log viewer

### DIFF
--- a/audit_log_viewer.py
+++ b/audit_log_viewer.py
@@ -32,7 +32,10 @@ def main():
         fh = sys.stdin
 
     for line in fh:
-        print(decode_and_decrypt_log_entry(line, private_key))
+        try:
+            print(decode_and_decrypt_log_entry(line, private_key))
+        except ValueError as e:
+            print(f"***** ERROR: Error in audit_log_viewer.py decrypting log file line: {str(e)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This ensures that if an audit log contains corrupted lines or lines encrypted with a different key, all of the decryptable lines are decyrpted and printed (previously, the log viewer crashed on first problematic line).